### PR TITLE
Telegram-Bot für Wachalarme

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.1",
     "json2csv": "^5.0.1",
+    "node-telegram-bot-api": "^0.61.0",
     "nodemailer": "^6.4.11",
     "npm": "^6.14.7",
     "passport": "^0.4.1",

--- a/server.js
+++ b/server.js
@@ -48,8 +48,8 @@ app.use(bodyParser.urlencoded({
 var sql_cfg = require('./server/sql_cfg')(fs, bcrypt, app_cfg);
 var sql = require('./server/sql_qry')(sql_cfg, app_cfg);
 var brk = require('./server/broker')(app_cfg, sql, uuidv4);
-var bot = require('./server/telegram')(app_cfg, sql);
-var waip = require('./server/waip')(io, sql, fs, brk, async, app_cfg);
+var telegram = require('./server/telegram')(app_cfg, sql);
+var waip = require('./server/waip')(io, sql, fs, brk, telegram, async, app_cfg);
 var saver = require('./server/saver')(app_cfg, sql, waip, uuidv4, io, remote_api);
 var api = require('./server/api')(io, sql, app_cfg, remote_api, saver);
 var socket = require('./server/socket')(io, sql, app_cfg, waip);

--- a/server.js
+++ b/server.js
@@ -48,6 +48,7 @@ app.use(bodyParser.urlencoded({
 var sql_cfg = require('./server/sql_cfg')(fs, bcrypt, app_cfg);
 var sql = require('./server/sql_qry')(sql_cfg, app_cfg);
 var brk = require('./server/broker')(app_cfg, sql, uuidv4);
+var bot = require('./server/telegram')(app_cfg, sql);
 var waip = require('./server/waip')(io, sql, fs, brk, async, app_cfg);
 var saver = require('./server/saver')(app_cfg, sql, waip, uuidv4, io, remote_api);
 var api = require('./server/api')(io, sql, app_cfg, remote_api, saver);

--- a/server/app_cfg.js
+++ b/server/app_cfg.js
@@ -47,6 +47,11 @@ app_cfg.rmld = {
   mail_from: 'xyz@xxx.xxx'//'keineantwort@wachalarm.info.tm'
 };
 
+// Einstellungen fuer den Telegram-Bot
+app_cfg.telegram = {
+  token: "123456789:ABC_abcdefghijklmnopqrstuvwxyzabcde"//vom @BotFather
+};
+
 // Schnittstelle um Daten von anderen Clients zu empfangen
 app_cfg.api = {
   enabled: true,

--- a/server/sql_cfg.js
+++ b/server/sql_cfg.js
@@ -142,6 +142,12 @@ module.exports = function (fs, bcrypt, app_cfg) {
         tw_consumer_secret TEXT,
         tw_access_token_key TEXT,
         tw_access_token_secret TEXT)`);
+      // Telegram-Chat-Tabelle erstellen
+      db.run(`CREATE TABLE waip_telegram_chats (
+        tg_chat_id INTEGER,
+        waip_wache_nr INTEGER,
+        waip_wache_name TEXT,
+        PRIMARY KEY (tg_chat_id, waip_wache_nr))`);
       // Export-Tabelle erstellen
       db.run(`CREATE TABLE waip_export (
         id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,

--- a/server/sql_cfg.js
+++ b/server/sql_cfg.js
@@ -144,10 +144,10 @@ module.exports = function (fs, bcrypt, app_cfg) {
         tw_access_token_secret TEXT)`);
       // Telegram-Chat-Tabelle erstellen
       db.run(`CREATE TABLE waip_telegram_chats (
-        tg_chat_id INTEGER,
-        waip_wache_nr INTEGER,
-        waip_wache_name TEXT,
-        PRIMARY KEY (tg_chat_id, waip_wache_nr))`);
+        chat_id INTEGER,
+        wache_nr INTEGER,
+        wache_name TEXT,
+        PRIMARY KEY (chat_id, wache_nr))`);
       // Export-Tabelle erstellen
       db.run(`CREATE TABLE waip_export (
         id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT UNIQUE,

--- a/server/sql_qry.js
+++ b/server/sql_qry.js
@@ -533,6 +533,8 @@ module.exports = function (db, app_cfg) {
       (
         SELECT id FROM waip_log ORDER BY id DESC LIMIT 50000, 100
       )`);
+
+    console.log(typ + ': ' + text);
   };
 
   function db_log_get_5000(callback) {

--- a/server/sql_qry.js
+++ b/server/sql_qry.js
@@ -858,11 +858,11 @@ module.exports = function (db, app_cfg) {
     });
   };
 
-  function db_telegram_get_chats(waip_id, callback) {
-    // Pruefen, welche Telegram-Chats fuer eine bestimmte Wache hinterlegt sind
-    db.all(`select distinct tg.tg_chat_id from waip_telegram_chats tg,
+  function db_telegram_get_chats_for_einsatz(waip_id, callback) {
+    // Pruefen, welche Telegram-Chats fuer die an einem Einsatz beteiligten Wachen hinterlegt sind
+    db.all(`select distinct tg.chat_id from waip_telegram_chats tg,
         (select nr_wache from waip_wachen w left join waip_einsatzmittel em on em.wachenname = w.name_wache where em.waip_einsaetze_ID = ?) wa
-      where wa.nr_wache like tg.waip_wache_nr||'%'`, [waip_id], function (err, liste) {
+      where wa.nr_wache like tg.wache_nr||'%'`, [waip_id], function (err, liste) {
       if (err == null && liste) {
         callback && callback(liste);
       } else {
@@ -871,10 +871,10 @@ module.exports = function (db, app_cfg) {
     });
   };
 
-  function db_telegram_get_wachen(chat_id, callback) {
+  function db_telegram_get_wachen_for_chat(chat_id, callback) {
     // Pruefen, welche Wachen fuer einen bestimmten Telegram-Chat hinterlegt sind
-    db.all(`select tg.waip_wache_nr, tg.waip_wache_name from waip_telegram_chats tg
-      where tg.tg_chat_id = ?`, [chat_id], function (err, rows) {
+    db.all(`select tg.wache_nr, tg.wache_name from waip_telegram_chats tg
+      where tg.chat_id = ?`, [chat_id], function (err, rows) {
       if (err == null && rows.length > 0) {
         callback && callback(rows);
       } else {
@@ -883,14 +883,16 @@ module.exports = function (db, app_cfg) {
     });
   }
 
-  function db_telegram_add_chat(chat_id, wache_nr, wache_name) {
+  function db_telegram_add_wache_to_chat(chat_id, wache_nr, wache_name) {
+    // Wachalarm zu einem Telegram-Chat hinzufügen
     db.run(`insert or replace into waip_telegram_chats
-      (tg_chat_id, waip_wache_nr, waip_wache_name) values (?,?,?)`, [chat_id, wache_nr, wache_name]);
+      (chat_id, wache_nr, wache_name) values (?,?,?)`, [chat_id, wache_nr, wache_name]);
   }
 
-  function db_telegram_remove_chat(chat_id, wache_nr) {
+  function db_telegram_remove_wache_from_chat(chat_id, wache_nr) {
+    // Wachalarm aus einem Telegram-Chat entfernen
     db.run(`delete from waip_telegram_chats
-      where tg_chat_id = ? and waip_wache_nr = ?`, [chat_id, wache_nr]);
+      where chat_id = ? and wache_nr = ?`, [chat_id, wache_nr]);
   }
 
   function db_vmtl_get_tw_account(list_data, callback) {
@@ -999,10 +1001,10 @@ module.exports = function (db, app_cfg) {
     db_vmtl_get_list: db_vmtl_get_list,
     db_vmtl_check_history: db_vmtl_check_history,
     db_vmtl_get_tw_account: db_vmtl_get_tw_account,
-    db_telegram_get_chats: db_telegram_get_chats,
-    db_telegram_get_wachen: db_telegram_get_wachen,
-    db_telegram_add_chat: db_telegram_add_chat,
-    db_telegram_remove_chat: db_telegram_remove_chat,
+    db_telegram_get_chats_for_einsatz: db_telegram_get_chats_for_einsatz,
+    db_telegram_get_wachen_for_chat: db_telegram_get_wachen_for_chat,
+    db_telegram_add_wache_to_chat: db_telegram_add_wache_to_chat,
+    db_telegram_remove_wache_from_chat: db_telegram_remove_wache_from_chat,
     db_export_get_for_rmld: db_export_get_for_rmld
   };
 

--- a/server/sql_qry.js
+++ b/server/sql_qry.js
@@ -524,9 +524,7 @@ module.exports = function (db, app_cfg) {
     // Log-Eintrag schreiben
     if (do_log) {
       db.run(`INSERT INTO waip_log (log_typ, log_text)
-        VALUES (
-        \'` + typ + `\',
-        \'` + text + `\')`);
+        VALUES (?,?)`, [typ, text]);
     };
     // Log auf 50.000 Datensätze begrenzen um Speicherplatz der DB zu begrenzen
     db.run(`DELETE FROM waip_log WHERE id IN

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -1,0 +1,152 @@
+module.exports = function (app_cfg, sql) {
+
+  // Module laden
+  const TelegramBot = require('node-telegram-bot-api');
+
+  // Verweis auf den Telegram-Bot, der mithilfe von 'polling' neue Benutzeranfragen abruft
+  const bot = new TelegramBot(app_cfg.telegram.token, { polling: true });
+
+  bot.on('message', msg => sendStartMessage(msg)); // bei irgendwelchen Nachrichten mit dem Start-Dialog antworten
+  bot.on('callback_query', onCallbackQuery); // Callback queries behandeln
+
+  function sendStartMessage(msg) {
+    let text = 'Hallo ' + msg.from.first_name + '! Ich kann dir helfen, Wachalarme in einen Telegram-Chat zu integrieren.\n\n';
+    
+    sql.db_telegram_get_wachen(msg.chat.id, function (data) {
+      if (!data) {
+        text += "Du hast momentan noch keine Wachalarme für diesen Chat hinterlegt.";
+      }
+      else {
+        text += "Du hast momentan folgende Wachalarme für diesen Chat hinterlegt:"
+        data.forEach(function (wache) {
+          text += "\n  - *" + wache.waip_wache_name + "* (" + wache.waip_wache_nr + ")";
+        });
+      }
+
+      text += "\n\nWas kann ich für dich tun?"
+      
+      bot.sendMessage(
+        chatId = msg.chat.id,
+        message = text,
+        options = {
+          parse_mode: 'Markdown',
+          reply_markup: {
+            inline_keyboard: [
+              [{
+                text: 'Ich möchte diesem Chat einen neuen Wachalarm hinzufügen.',
+                callback_data: JSON.stringify({ action: "add_alarm" })
+              }],
+              [{
+                text: 'Ich möchte einen der Wachalarme aus diesem Chat entfernen.',
+                callback_data: JSON.stringify({ action: "remove_alarm" })
+              }]
+                .slice(end = (!data) ? 1 : 0) // falls es noch keine Alarme gibt, nur die erste Auswahl zurückgeben
+            ],
+            one_time_keyboard: true
+          }
+        });
+    });
+  }
+
+  function onCallbackQuery(callbackQuery) {
+    const msg = callbackQuery.message;
+    const callback_data = JSON.parse(callbackQuery.data);
+    let text = msg.text;
+
+    if (callback_data.action == "add_alarm") {
+      if (!callback_data.typ && !callback_data.nr) {
+        bot.editMessageText('Klasse! Welche Wachalarme möchtest du denn erhalten?',
+          options = {
+            chat_id: msg.chat.id, message_id: msg.message_id,
+            reply_markup: {
+              inline_keyboard: [
+                [{
+                  text: 'Zeige den Wachalarm einer einzelnen Wache (z.B. Feuerwache, Rettungswache etc.) an.',
+                  callback_data: JSON.stringify({ action: "add_alarm", typ: "wache" })
+                }],
+                [{
+                  text: 'Zeige alle Wachalarme der Wachen eines Trägers (Amt, amtsfreie Gemeinde, Stadt) an.',
+                  callback_data: JSON.stringify({ action: "add_alarm", typ: "traeger" })
+                }],
+                [{
+                  text: 'Zeige alle Wachalarme des gesamten Kreises (egal ob für Feuerwehr oder Rettungsdienst) an.',
+                  callback_data: JSON.stringify({
+                    action: "add_alarm", typ: "kreis"
+                  })
+                }]
+              ],
+              one_time_keyboard: true
+            }
+          });
+      }
+      else if (callback_data.typ) {
+        text = "Super! Welchen Wachalarm möchtest du genau erhalten?";
+        sql.db_wache_get_all(function (data) {
+          let inline_keyboard = [];
+          data.forEach(function (wache) {
+            if (wache.typ == callback_data.typ && wache.nr) {
+              inline_keyboard.push([{
+                text: wache.name,
+                callback_data: JSON.stringify({ action: "add_alarm", nr: wache.nr })
+              }]);
+            }
+          });
+
+          bot.editMessageText(text, options = {
+            chat_id: msg.chat.id, message_id: msg.message_id,
+            reply_markup: { inline_keyboard: inline_keyboard, one_time_keyboard: true }
+          });
+        });
+      }
+      else if (callback_data.nr) {
+        sql.db_wache_vorhanden(callback_data.nr, function (wache) {
+          if (wache) {
+            sql.db_telegram_add_chat(msg.chat.id, wache.nr, wache.name);
+
+            let text = "Du erhältst jetzt Wachalarme für *" + wache.name + "* (" + wache.nr + ")";
+            bot.editMessageText(text, options = {
+              chat_id: msg.chat.id,
+              message_id: msg.message_id,
+              parse_mode: 'Markdown'
+            });
+            
+            text += "\n\nWas kann ich für dich tun?"
+          }
+        });
+      }
+    }
+
+    if (callback_data.action == "remove_alarm") {
+      if (!callback_data.nr) {
+        text = "Okay. Welcher Wachalarm soll aus diesem Chat wieder entfernt werden?";
+        sql.db_telegram_get_wachen(msg.chat.id, function (data) {
+          let inline_keyboard = [];
+          data.forEach(function (wache) {
+            inline_keyboard.push([{
+              text: wache.waip_wache_name + " (" + wache.waip_wache_nr +")",
+              callback_data: JSON.stringify({ action: "remove_alarm", nr: wache.waip_wache_nr })
+            }]);
+          });
+          bot.editMessageText(text, options = {
+            chat_id: msg.chat.id, message_id: msg.message_id,
+            reply_markup: { inline_keyboard: inline_keyboard, one_time_keyboard: true }
+          });
+        });
+      }
+      else {
+        sql.db_wache_vorhanden(callback_data.nr, function (wache) {
+          if (wache) {
+            sql.db_telegram_remove_chat(msg.chat.id, wache.nr, wache.name);
+            
+            let text = "Du erhältst jetzt *keine* Wachalarme mehr für *" + wache.name + "* (" + wache.nr + ")";
+            bot.editMessageText(text, options = {
+              chat_id: msg.chat.id,
+              message_id: msg.message_id,
+              parse_mode: 'Markdown'
+            });
+          }
+        });
+      }
+    }
+  }
+}

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -6,47 +6,55 @@ module.exports = function (app_cfg, sql) {
   // Verweis auf den Telegram-Bot, der mithilfe von 'polling' neue Benutzeranfragen abruft
   const bot = new TelegramBot(app_cfg.telegram.token, { polling: true });
 
-  bot.on('message', msg => sendStartMessage(msg)); // bei irgendwelchen Nachrichten mit dem Start-Dialog antworten
+  bot.on('message', msg => sendStartMessage(msg, withUserInteraction = true)); // bei irgendwelchen Nachrichten mit dem Start-Dialog antworten
   bot.on('callback_query', onCallbackQuery); // Callback queries behandeln
 
   function sendStartMessage(msg) {
-    let text = 'Hallo ' + msg.from.first_name + '! Ich kann dir helfen, Wachalarme in einen Telegram-Chat zu integrieren.\n\n';
+    let text = (withUserInteraction) ? 'Ich kann dir helfen, Wachalarme in einen Telegram-Chat zu integrieren.\n\n' : '';
 
     sql.db_telegram_get_wachen(msg.chat.id, function (data) {
       if (!data) {
-        text += "In diesem Chat sind momentan *noch keine Wachalarme* hinterlegt.";
+        text += 'In diesem Chat sind momentan *noch keine Wachalarme* hinterlegt.';
       }
       else {
-        text += "In diesem Chat sind momentan folgende Wachalarme hinterlegt:"
+        text += 'In diesem Chat sind momentan folgende Wachalarme hinterlegt:'
         data.forEach(function (wache) {
-          text += "\n  - *" + wache.waip_wache_name + "* (" + wache.waip_wache_nr + ")";
+          text += '\n  - *' + wache.waip_wache_name + '*' + ((wache.waip_wache_nr.toString().length<6) ? ' (alle Wachen)' : '');
         });
       }
 
-      text += "\n\nWas kann ich für dich tun?"
-      bot.sendMessage(
-        chatId = msg.chat.id,
-        message = text,
-        options = {
-          parse_mode: 'Markdown',
-          reply_markup: {
-            inline_keyboard: [
-              [{
-                text: 'Ich möchte diesem Chat einen neuen Wachalarm hinzufügen.',
-                callback_data: JSON.stringify({ action: "add_alarm", nr: "" })
-              }],
-              [{
-                text: 'Ein vorhanderner Wachalarm soll wieder entfernt werden.',
-                callback_data: JSON.stringify({ action: "remove_alarm" })
-              }].slice((!data) ? 1 : 0), // falls es noch keine Alarme gibt, dieses Element auslassen
-              [{
-                text: 'Danke. Es gibt nix weiter zu tun.',
-                callback_data: JSON.stringify({ action: "finish", nr: "" })
-              }]
-            ],
-            one_time_keyboard: true
-          }
-        });
+      if (withUserInteraction) {
+        text += '\n\nWas möchtest du gern tun?'
+        bot.sendMessage(
+          chatId = msg.chat.id,
+          message = text,
+          options = {
+            parse_mode: 'Markdown',
+            reply_markup: {
+              inline_keyboard: [
+                [{
+                  text: 'Ich möchte diesem Chat einen neuen Wachalarm hinzufügen.',
+                  callback_data: JSON.stringify({ action: 'add_alarm', nr: '' })
+                }],
+                [{
+                  text: 'Ein vorhanderner Wachalarm soll wieder entfernt werden.',
+                  callback_data: JSON.stringify({ action: 'remove_alarm' })
+                }].slice((!data) ? 1 : 0), // falls es noch keine Alarme gibt, dieses Element auslassen
+                [{
+                  text: 'Danke. Es gibt nix weiter zu tun.',
+                  callback_data: JSON.stringify({ action: 'finish', nr: '' })
+                }]
+              ],
+              one_time_keyboard: true
+            }
+          });
+      }
+      else {
+        bot.sendMessage(
+          chatId = msg.chat.id,
+          message = text,
+          options = { parse_mode: 'Markdown' });
+      }
     });
   }
 
@@ -55,13 +63,12 @@ module.exports = function (app_cfg, sql) {
     const callback_data = (callbackQuery.data) ? JSON.parse(callbackQuery.data) : {};
     let text = msg.text;
 
-    if (callback_data.action == "add_alarm") {
+    if (callback_data.action == 'add_alarm') {
       if (!callback_data.final) {
-        switch (callback_data.nr.toString().length)
-        {
-          case 0: text = "Super! Aus welchem Landkreis möchtest du denn Wachalarme erhalten?"; break;
-          case 2: text = "Alles klar! Wo genau in diesem Landkreis soll es denn sein?"; break;
-          case 4: text = "Perfekt! Von welcher *Wache* möchtest du denn Wachalarme erhalten?"; break;
+        switch (callback_data.nr.toString().length) {
+          case 0: text = 'Super! Aus welchem Landkreis möchtest du denn Wachalarme erhalten?'; break;
+          case 2: text = 'Alles klar! Wo genau in diesem Landkreis soll es denn sein?'; break;
+          case 4: text = 'Perfekt! Von welcher *Wache* möchtest du denn Wachalarme erhalten?'; break;
         }
 
         sql.db_wache_get_all(function (data) {
@@ -69,21 +76,21 @@ module.exports = function (app_cfg, sql) {
           data.forEach(function (wache) {
             if (wache.nr == callback_data.nr || (wache.nr.toString().startsWith(callback_data.nr) && wache.nr.toString().length == callback_data.nr.toString().length + 2)) {
               inline_keyboard.push([{
-                text: (wache.nr == callback_data.nr) ? wache.name + " (alle Wachen)" : wache.name,
-                callback_data: JSON.stringify({ action: "add_alarm", nr: wache.nr, final: (wache.typ == 'wache' || wache.nr == callback_data.nr) })
+                text: (wache.nr == callback_data.nr) ? wache.name + ' (alle Wachen)' : wache.name,
+                callback_data: JSON.stringify({ action: 'add_alarm', nr: wache.nr, final: (wache.typ == 'wache' || wache.nr == callback_data.nr) })
               }]);
             }
           });
           if (callback_data.nr.toString().length >= 2) {
             inline_keyboard.push([{
-              text: "« zurück",
-              callback_data: JSON.stringify({ action: "add_alarm", nr: callback_data.nr.toString().slice(0, -2) })
+              text: '« zurück',
+              callback_data: JSON.stringify({ action: 'add_alarm', nr: callback_data.nr.toString().slice(0, -2) })
             }]);
           }
           else {
             inline_keyboard.push([{
-              text: "« abbrechen",
-              callback_data: JSON.stringify({ action: "restart", nr: callback_data.nr.toString().slice(0, -2) })
+              text: '« abbrechen',
+              callback_data: JSON.stringify({ action: 'restart', nr: callback_data.nr.toString().slice(0, -2) })
             }]);
           }
 
@@ -99,25 +106,27 @@ module.exports = function (app_cfg, sql) {
           if (wache) {
             sql.db_telegram_add_chat(msg.chat.id, wache.nr, wache.name);
 
-            let text = "Erledigt. Du erhältst jetzt Wachalarme für *" + wache.name + "* (" + wache.nr + ")";
+            let text = 'Du erhältst jetzt Wachalarme für *' + wache.name + '* (' + wache.nr + ')';
             bot.editMessageText(text, options = {
               chat_id: msg.chat.id, message_id: msg.message_id,
               parse_mode: 'Markdown'
             });
+
+            sendStartMessage(msg, withUserInteraction = true);
           }
         });
       }
     }
 
-    if (callback_data.action == "remove_alarm") {
+    if (callback_data.action == 'remove_alarm') {
       if (!callback_data.nr) {
-        text = "Okay. Welcher Wachalarm soll aus diesem Chat wieder entfernt werden?";
+        text = 'Okay. Welcher Wachalarm soll aus diesem Chat wieder entfernt werden?';
         sql.db_telegram_get_wachen(msg.chat.id, function (data) {
           let inline_keyboard = [];
           data.forEach(function (wache) {
             inline_keyboard.push([{
-              text: wache.waip_wache_name + " (" + wache.waip_wache_nr + ")",
-              callback_data: JSON.stringify({ action: "remove_alarm", nr: wache.waip_wache_nr })
+              text: wache.waip_wache_name + ' (' + wache.waip_wache_nr + ')',
+              callback_data: JSON.stringify({ action: 'remove_alarm', nr: wache.waip_wache_nr })
             }]);
           });
           bot.editMessageText(text, options = {
@@ -131,20 +140,26 @@ module.exports = function (app_cfg, sql) {
           if (wache) {
             sql.db_telegram_remove_chat(msg.chat.id, wache.nr, wache.name);
 
-            let text = "Erledigt. Du erhältst jetzt *keine* Wachalarme mehr für *" + wache.name + "* (" + wache.nr + ")";
+            let text = 'Du erhältst jetzt *keine* Wachalarme mehr für *' + wache.name + '* (' + wache.nr + ')';
             bot.editMessageText(text, options = {
               chat_id: msg.chat.id,
               message_id: msg.message_id,
               parse_mode: 'Markdown'
             });
+
+            sendStartMessage(msg, withUserInteraction = true);
           }
         });
       }
     }
 
-    if (callback_data.action == "restart") {
+    if (callback_data.action == 'restart') {
       bot.deleteMessage(msg.chat.id, msg.message_id);
-      sendStartMessage(msg);
+      sendStartMessage(msg, withUserInteraction = true);
+    }
+    if (callback_data.action == 'finish') {
+      bot.deleteMessage(msg.chat.id, msg.message_id);
+      sendStartMessage(msg, withUserInteraction = false);
     }
   }
 }

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -7,11 +7,15 @@ module.exports = function (app_cfg, sql) {
   const bot = new TelegramBot(app_cfg.telegram.token, { polling: true });
 
   bot.on('message', msg => sendStartMessage(msg, withUserInteraction = true)); // bei irgendwelchen Nachrichten mit dem Start-Dialog antworten
-  bot.on('callback_query', onCallbackQuery); // Callback queries behandeln
+  bot.on('callback_query', onCallbackQuery); // Callback-Queries behandeln (bei Auswahl einer der gesendeten Antwortmöglichkeiten, die vorher als inline_keyboard verschickt wurden)
 
+  /**
+   * Senden der Start-Narchricht (führt ein sendMessage durch)
+   */
   function sendStartMessage(msg) {
     let text = (withUserInteraction) ? 'Ich kann dir helfen, Wachalarme in einen Telegram-Chat zu integrieren.\n\n' : '';
 
+    // ermitteln, welche Wachalarme für diesen Chat schon hinterlegt sind
     sql.db_telegram_get_wachen(msg.chat.id, function (data) {
       if (!data) {
         text += 'In diesem Chat sind momentan *noch keine Wachalarme* hinterlegt.';
@@ -23,8 +27,14 @@ module.exports = function (app_cfg, sql) {
         });
       }
 
-      if (withUserInteraction) {
-        text += '\n\nWas möchtest du gern tun?'
+      if (!withUserInteraction) {
+        bot.sendMessage(
+          chatId = msg.chat.id,
+          message = text,
+          options = { parse_mode: 'Markdown' });
+      }
+      else {
+        // Nachricht mit Antwortmöglichkeiten versenden
         bot.sendMessage(
           chatId = msg.chat.id,
           message = text,
@@ -53,20 +63,21 @@ module.exports = function (app_cfg, sql) {
             }
           });
       }
-      else {
-        bot.sendMessage(
-          chatId = msg.chat.id,
-          message = text,
-          options = { parse_mode: 'Markdown' });
-      }
     });
   }
 
+  /**
+   * auf die Auswahl einer Antwortmöglichkeit (die vorher als inline_keyboard angeboten wurden) reagieren
+   * (führt in der Regel ein editMessageText der Ursprungsnachricht durch)
+   */
   function onCallbackQuery(callbackQuery) {
-    const msg = callbackQuery.message;
-    const callback_data = (callbackQuery.data) ? JSON.parse(callbackQuery.data) : {};
-    let text = msg.text;
+    const msg = callbackQuery.message; // die Nachricht, deren Auswahlmöglichkeit gewählt wurde
+    const callback_data = (callbackQuery.data) ? JSON.parse(callbackQuery.data) : {}; // die Callback-Daten deserialiseren
+    let text = msg.text; // der (geänderte) Text der Nachricht
 
+    /**
+     * einen neuen Wachalarm hinzufügen
+     */
     if (callback_data.action == 'add_alarm') {
       if (!callback_data.final) {
         switch (callback_data.nr.toString().length) {
@@ -75,9 +86,11 @@ module.exports = function (app_cfg, sql) {
           case 4: text = 'Perfekt! Von welcher *Wache* möchtest du denn Wachalarme erhalten?'; break;
         }
 
+        // Auswahlmöglichkeiten anbieten: Kreise/Träger/Wachen
         sql.db_wache_get_all(function (data) {
           let inline_keyboard = [];
           data.forEach(function (wache) {
+            // Antwortmöglichkeiten hierarchisch anzeigen: Erst Kreise, dann die Träger des ausgwählten Kreises und dann alle Wachen des ausgewählten Trägers
             if (wache.nr == callback_data.nr || (wache.nr.toString().startsWith(callback_data.nr) && wache.nr.toString().length == callback_data.nr.toString().length + 2)) {
               inline_keyboard.push([{
                 text: (wache.nr == callback_data.nr) ? wache.name + ' (alle Wachen)' : wache.name,
@@ -105,6 +118,7 @@ module.exports = function (app_cfg, sql) {
           });
         });
       }
+      // Auswahl eines Wachalarms => in die Datenbank speichern
       else if (callback_data.nr) {
         sql.db_wache_vorhanden(callback_data.nr, function (wache) {
           if (wache) {
@@ -122,7 +136,11 @@ module.exports = function (app_cfg, sql) {
       }
     }
 
+    /**
+     * einen vorhandenen Wachalarm wieder entfernen
+     */
     if (callback_data.action == 'remove_alarm') {
+      // Auswahlmöglichkeit: vorhandene Wachalarme des aktuellen Chats
       if (!callback_data.nr) {
         text = 'Okay. Welcher Wachalarm soll aus diesem Chat wieder entfernt werden?';
         sql.db_telegram_get_wachen(msg.chat.id, function (data) {
@@ -139,6 +157,7 @@ module.exports = function (app_cfg, sql) {
           });
         });
       }
+      // Auswahl eines Wachalarms => aus der Datenbank entfernen
       else {
         sql.db_wache_vorhanden(callback_data.nr, function (wache) {
           if (wache) {
@@ -157,9 +176,13 @@ module.exports = function (app_cfg, sql) {
       }
     }
 
+    /**
+     * einen Testalarm verschicken
+     */
     if (callback_data.action == 'test_alarm') {
+      // Auswahlmöglichkeiten: Sekunden, bis der Testalarm verschickt wird
       if (!callback_data.duration) {
-        text = 'Na klar! Wann möchtest du den Wachalarm erhalten?';
+        text = 'Na klar! Wann möchtest du den Test-Alarm erhalten?';
         let inline_keyboard = [[]];
         [3, 10, 30].forEach(sec => inline_keyboard[0].push({
           text: 'In ' + sec + ' Sekunden',
@@ -170,39 +193,55 @@ module.exports = function (app_cfg, sql) {
           reply_markup: { inline_keyboard: inline_keyboard, one_time_keyboard: true }
         });
       }
+      // Auswahl einer Zeit => Versenden des Testalarms planen
       else {
         new Promise(resolve => setTimeout(resolve, callback_data.duration * 1000))
           .then(function () {
-            text = formatAlarm(msg.chat.id, { "einsatzdaten": { "nummer": "0815", "alarmzeit": "01.01.19&01:00", "art": "Sonstiges", "stichwort": "S:Testeinsatz", "sondersignal": 1, "besonderheiten": "DEMO Wachalarm-IP-Web - Testeinsatz", "patient": "" }, "ortsdaten": { "ort": "Elsterwerda", "ortsteil": "Biehla", "strasse": "Haidaer Str. 47A", "objekt": "", "objektnr": "-1", "objektart": "", "wachfolge": "611302", "wgs84_x": "52.471244", "wgs84_y": "13.502943" }, "alarmdaten": [{ "typ": "ALARM", "netzadresse": "", "wachenname": "EE FW Elsterwerda", "einsatzmittel": "FL EE 02/14-01", "zeit_a": "18:41", "zeit_b": "", "zeit_c": "" }] });
+            text = formatAlarm({ "einsatzdaten": { "nummer": "0815", "alarmzeit": "01.01.19&01:00", "art": "Sonstiges", "stichwort": "S:Testeinsatz", "sondersignal": 1, "besonderheiten": "DEMO Wachalarm-IP-Web - Testeinsatz", "patient": "" }, "ortsdaten": { "ort": "Elsterwerda", "ortsteil": "Biehla", "strasse": "Haidaer Str. 47A", "objekt": "", "objektnr": "-1", "objektart": "", "wachfolge": "611302", "wgs84_x": "52.471244", "wgs84_y": "13.502943" }, "alarmdaten": [{ "typ": "ALARM", "netzadresse": "", "wachenname": "EE FW Elsterwerda", "einsatzmittel": "FL EE 02/14-01", "zeit_a": "18:41", "zeit_b": "", "zeit_c": "" }] });
             bot.sendMessage(msg.chat.id, text);
           });
         bot.deleteMessage(msg.chat.id, msg.message_id);
       }
     }
 
+    /**
+     * von vorn beginnen
+     */
     if (callback_data.action == 'restart') {
       bot.deleteMessage(msg.chat.id, msg.message_id);
       sendStartMessage(msg, withUserInteraction = true);
     }
+
+    /**
+     * beenden des Dialogs
+     */
     if (callback_data.action == 'finish') {
       bot.deleteMessage(msg.chat.id, msg.message_id);
       sendStartMessage(msg, withUserInteraction = false);
     }
   }
 
+  /**
+   * aus einem Alarm eine Textnachricht erstellen
+   */
   function formatAlarm(alarm) {
     // Symbol für Sondersignal am beginn anfügen
     let text = (alarm.einsatzdaten.sondersignal) ? '\u{1F6A8}' /*Unicode Character 'POLICE CARS REVOLVING LIGHT' (U+1F6A8)*/ : '\u{1F515}' /*Unicode Character 'BELL WITH CANCELLATION STROKE' (U+1F515)*/;
 
     text += ' ' + alarm.einsatzdaten.alarmzeit; // Datum und Uhrzeit anfügen
-    text += ' ' + alarm.einsatzdaten.stichwort;// Stichwort anfügen
-    text += ' \u{1F310} '; //Symbol für Orte anfügen Unicode Character 'GLOBE WITH MERIDIANS' (U+1F310)
-    text += alarm.ortsdaten.ort + ((alarm.ortsdaten.ortsteil) ? ', '+ alarm.ortsdaten.ortsteil : ''); // Ort und Ortsteil anfügen
+    text += ' ' + alarm.einsatzdaten.stichwort; // Stichwort anfügen
+    text += ' \u{1F310} '; // Symbol für Orte anfügen Unicode Character 'GLOBE WITH MERIDIANS' (U+1F310)
+    text += alarm.ortsdaten.ort + ((alarm.ortsdaten.ortsteil) ? ', ' + alarm.ortsdaten.ortsteil : ''); // Ort und Ortsteil anfügen
 
     if (alarm.alarmdaten) {
-      //Wachen, Unicode Character 'FIRE ENGINE' (U+1F692) and 'RIGHTWARDS WHITE ARROW' (U+21E8)
+      // Wachen, Unicode Character 'FIRE ENGINE' (U+1F692) and 'RIGHTWARDS WHITE ARROW' (U+21E8)
       text += ' \u{1F692} \u{21E8} ';
-      alarm.alarmdaten.forEach(alarmdatum => text += alarmdatum.einsatzmittel + ' ');
+      alarm.alarmdaten.forEach(alarmdatum => {
+        if (!text.includes(alarmdatum.wachenname)) {
+          text += alarmdatum.wachenname + ', '; // Namen aller beteiligten Wachen anfügen
+        }
+      });
+      text = text.slice(0, -2);
     }
 
     return text;

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -204,5 +204,12 @@ module.exports = function (app_cfg, sql) {
       text += ' \u{1F692} \u{21E8} ';
       alarm.alarmdaten.forEach(alarmdatum => text += alarmdatum.einsatzmittel + ' ');
     }
+
+    return text;
+  }
+
+  return {
+    bot: bot,
+    formatAlarm: formatAlarm
   }
 }

--- a/server/telegram.js
+++ b/server/telegram.js
@@ -16,14 +16,14 @@ module.exports = function (app_cfg, sql) {
     let text = (withUserInteraction) ? 'Ich kann dir helfen, Wachalarme in einen Telegram-Chat zu integrieren.\n\n' : '';
 
     // ermitteln, welche Wachalarme für diesen Chat schon hinterlegt sind
-    sql.db_telegram_get_wachen(msg.chat.id, function (data) {
+    sql.db_telegram_get_wachen_for_chat(msg.chat.id, function (data) {
       if (!data) {
         text += 'In diesem Chat sind momentan *noch keine Wachalarme* hinterlegt.';
       }
       else {
         text += 'In diesem Chat sind momentan folgende Wachalarme hinterlegt:'
         data.forEach(function (wache) {
-          text += '\n  - *' + wache.waip_wache_name + '*' + ((wache.waip_wache_nr.toString().length < 6) ? ' (alle Wachen)' : '');
+          text += '\n  - *' + wache.wache_name + '*' + ((wache.wache_nr.toString().length < 6) ? ' (alle Wachen)' : '');
         });
       }
 
@@ -122,7 +122,7 @@ module.exports = function (app_cfg, sql) {
       else if (callback_data.nr) {
         sql.db_wache_vorhanden(callback_data.nr, function (wache) {
           if (wache) {
-            sql.db_telegram_add_chat(msg.chat.id, wache.nr, wache.name);
+            sql.db_telegram_add_wache_to_chat(msg.chat.id, wache.nr, wache.name);
 
             let text = 'Du erhältst jetzt Wachalarme für *' + wache.name + '* (' + wache.nr + ')';
             bot.editMessageText(text, options = {
@@ -143,12 +143,12 @@ module.exports = function (app_cfg, sql) {
       // Auswahlmöglichkeit: vorhandene Wachalarme des aktuellen Chats
       if (!callback_data.nr) {
         text = 'Okay. Welcher Wachalarm soll aus diesem Chat wieder entfernt werden?';
-        sql.db_telegram_get_wachen(msg.chat.id, function (data) {
+        sql.db_telegram_get_wachen_for_chat(msg.chat.id, function (data) {
           let inline_keyboard = [];
           data.forEach(function (wache) {
             inline_keyboard.push([{
-              text: wache.waip_wache_name + ' (' + wache.waip_wache_nr + ')',
-              callback_data: JSON.stringify({ action: 'remove_alarm', nr: wache.waip_wache_nr })
+              text: wache.wache_name + ' (' + wache.wache_nr + ')',
+              callback_data: JSON.stringify({ action: 'remove_alarm', nr: wache.wache_nr })
             }]);
           });
           bot.editMessageText(text, options = {
@@ -161,7 +161,7 @@ module.exports = function (app_cfg, sql) {
       else {
         sql.db_wache_vorhanden(callback_data.nr, function (wache) {
           if (wache) {
-            sql.db_telegram_remove_chat(msg.chat.id, wache.nr, wache.name);
+            sql.db_telegram_remove_wache_from_chat(msg.chat.id, wache.nr, wache.name);
 
             let text = 'Du erhältst jetzt *keine* Wachalarme mehr für *' + wache.name + '* (' + wache.nr + ')';
             bot.editMessageText(text, options = {

--- a/server/waip.js
+++ b/server/waip.js
@@ -49,14 +49,14 @@ module.exports = function (io, sql, fs, brk, telegram, async, app_cfg) {
       sql.db_telegram_get_chats_for_einsatz(waip_id, function (list) {
         if (list) {
           let text = telegram.formatAlarm(einsatz_daten);
-          list.forEach(function(chat) {
-            try {
-            telegram.bot.sendMessage(chat.chat_id, text);
-            }
-            catch (err) {
-              console.log(err);
-            }
+          list.forEach(chat => {
+            telegram.bot.sendMessage(chat.chat_id, text)
+              .catch(err => sql.db_log('Telegram', 'Fehler beim Versenden von Einsatz ' + waip_id + ' an Chat '+ chat_id +': ' + JSON.stringify(err)));
+            sql.db_log('Telegram', 'Einsatz ' + waip_id + ' wurde an Chat ' + chat_id + ' gesendet.');
           });
+        }
+        else {
+          sql.db_log('Telegram', 'Keine Telegram-Chats für Wachen im Einsatz ' + waip_id + ' hinterlegt.');
         }
       });
     });

--- a/server/waip.js
+++ b/server/waip.js
@@ -1,4 +1,4 @@
-module.exports = function (io, sql, fs, brk, async, app_cfg) {
+module.exports = function (io, sql, fs, brk, telegram, async, app_cfg) {
 
   // Module laden
   const {
@@ -48,7 +48,15 @@ module.exports = function (io, sql, fs, brk, async, app_cfg) {
       // pruefen, ob für die beteiligten Wachen Telegram-Chats hinterlegt sind, falls ja: Benachrichtigung senden
       sql.db_telegram_get_chats(waip_id, function (list) {
         if (list) {
-
+          let text = telegram.formatAlarm(einsatz_daten);
+          list.forEach(function(chat) {
+            try {
+            telegram.bot.sendMessage(chat.tg_chat_id, text);
+            }
+            catch (err) {
+              console.log(err);
+            }
+          });
         }
       });
     });

--- a/server/waip.js
+++ b/server/waip.js
@@ -46,12 +46,12 @@ module.exports = function (io, sql, fs, brk, telegram, async, app_cfg) {
         };
       });
       // pruefen, ob für die beteiligten Wachen Telegram-Chats hinterlegt sind, falls ja: Benachrichtigung senden
-      sql.db_telegram_get_chats(waip_id, function (list) {
+      sql.db_telegram_get_chats_for_einsatz(waip_id, function (list) {
         if (list) {
           let text = telegram.formatAlarm(einsatz_daten);
           list.forEach(function(chat) {
             try {
-            telegram.bot.sendMessage(chat.tg_chat_id, text);
+            telegram.bot.sendMessage(chat.chat_id, text);
             }
             catch (err) {
               console.log(err);

--- a/server/waip.js
+++ b/server/waip.js
@@ -45,6 +45,12 @@ module.exports = function (io, sql, fs, brk, async, app_cfg) {
           sql.db_log('VMTL', 'Keine Vermittler-Liste für Wachen im Einsatz ' + waip_id + ' hinterlegt. Rückmeldung wird nicht verteilt.');
         };
       });
+      // pruefen, ob für die beteiligten Wachen Telegram-Chats hinterlegt sind, falls ja: Benachrichtigung senden
+      sql.db_telegram_get_chats(waip_id, function (list) {
+        if (list) {
+
+        }
+      });
     });
   };
 


### PR DESCRIPTION
Hallo zusammen,

der PR enthält eine Erweiterung, mit der Wachalarme in Chats des [Telegram](https://telegram.org/)-Messengers integriert werden können. Dazu kann man in Telegram mit dem Bot interagieren, um bestimmte Wachalarme für bestimmte Chats zu registrieren. Diese Zuordnung wird dann in der WAIP-Web-Datenbank gespeichert. Bei einem Alarm werden dann alles Chats ermittelt, die Alarme für die am Einsatz beteiligten Wachen registriert haben, und eine EvI-artige Nachricht in den Chat versendet.

![Unbenannt](https://user-images.githubusercontent.com/12428377/227784838-32d31b63-d64c-408e-8ed8-b2f098241657.PNG)

Vorteil von Wachalarmen via Telegram: Einfach zu benutzen, da es ein normaler Messenger-Dienst ist. Die Nachrichten kommen sofort mit Notifications an. Die Notifications können auch individuell konfiguriert werden, sodass man z.B. individuelle Alarmierungstöne hinterlegen kann.

![Unbenannt](https://user-images.githubusercontent.com/12428377/227785518-e958bcd3-2050-4e9b-8582-8bdc6e40c59e.PNG)

Der Wachalarm-Bot kann folgendermaßen verwendet werden:
 * **privater Chat**: Man schreibt den Wachalarm-Bot direkt an und kann seine persönlichen Wachalarme zusammenstellen.
 * **Gruppen-Chat**: Man kann den Wachalarm-Bot als Mitglied in eine Gruppe aufnehmen und die Wachalarme für diese Gruppe konfigurieren (dazu die `/start` bzw. `/start@wachalarm_bot`-Nachricht in die Gruppe schreiben)
 * **Kanal/Channel** (nur Administratoren können Nachrichten schreiben): Man kann den Wachalarm-Bot als Kanal-Administrator hinzufügen und die Wachalarme für diesen Kanal konfigurieren  (dazu die `/start` bzw. `/start@wachalarm_bot`-Nachricht in die Gruppe schreiben).

### Features

Für jeden privaten Chat, jede Gruppe und jeden Kanal können individuelle Wachalarme registriert werden.
 * registrierte Wachalarme anzeigen
 * neuen Wachalarm hinzufügen
 * vorhanden Wachalarm wieder entfernen
 * Hinweistext für die Konfiguration individueller Alarmtöne für einen Chat
 * Testalarm senden


![Recording 2023-03-26 at 16 38 17](https://user-images.githubusercontent.com/12428377/227785304-c19a3830-83de-492e-a70d-e77c14294a36.gif)

![Recording 2023-03-26 at 16 42 55](https://user-images.githubusercontent.com/12428377/227785099-17e0fca8-e6e4-4d49-866e-9d6fb55bc1ba.gif)

### Individuelle Alarmierungstöne

Für jeden Telegram-Chat können Benachrichtigungen (z.B. Alarmierungstöne und Wichtigkeit) individuell eingestellt werden. 

1. Klicke oben rechts auf das Symbol mit den drei Punkten.
2. Wähle Stumm aus.
3. Klicke auf Anpassen.
4. Unter Ton kannst du einen Systemton auswählen oder einen Ton hochladen

Spezielle SMS-Alarmierungstöne kannst du beispielsweise unter https://www.regan.ch/sms-alarmierungstoene/ oder https://safereach.com/de/wissen/10-alarmtoene-die-sie-garantiert-nicht-ueberhoren/ herunterladen und dann als Benachrichtigungston für den Chat verwenden.

### Installation

Die `/newbot`-Nachricht and den [BotFather](https://telegram.me/BotFather) schicken, Name, Beschreibung und Bild des Bots eingeben, fertig. Das erhaltene API-Token dann in `app_cfg.telegram.token` schreiben. Fertig.